### PR TITLE
Fixed a JSON circular reference issue

### DIFF
--- a/src/main/java/com/gwais/sk_users/model/SkRole.java
+++ b/src/main/java/com/gwais/sk_users/model/SkRole.java
@@ -5,6 +5,8 @@ import java.util.Set;
 
 import org.springframework.security.core.GrantedAuthority;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -36,6 +38,7 @@ public class SkRole implements GrantedAuthority, Serializable {
     private String roleCode;
     
     @ManyToMany(mappedBy = "roles")  // This field is mapped by the "roles" field in the User entity
+    @JsonIgnore  // Prevent serialization of users
     private Set<SmUser> users;
     
     // Constructors


### PR DESCRIPTION
Fixed circular reference issue in SkRole many-to-many relationship by adding @JsonIgnore to prevent infinite recursion during JSON serialization.